### PR TITLE
feat: scaffold monorepo with server and client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables
+SERVER_PORT=3000
+CLIENT_PORT=5173
+JWT_SECRET=change-me

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  env: { node: true, browser: true, es2021: true },
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  ignorePatterns: ['dist', 'build'],
+  rules: {}
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # App_connect
+
+Monorepo containing a proof-of-concept self-hosted social/chat app.
+
+## Development
+
+```bash
+pnpm install
+pnpm run dev
+```
+
+This runs both server and client in watch mode.

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json tsconfig.node.json vite.config.ts ./
+RUN npm install
+COPY src ./src
+COPY public ./public
+RUN npm run build
+CMD ["npm", "run", "preview", "--", "--port", "5173"]

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "app_connect-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "zustand": "^4.5.2",
+    "markdown-it": "^14.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/client/public/manifest.webmanifest
+++ b/client/public/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "App Connect",
+  "short_name": "AppConnect",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": []
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,19 @@
+import { Routes, Route, Link } from 'react-router-dom';
+import Login from './pages/Login';
+import Home from './pages/Home';
+import Room from './pages/Room';
+
+export default function App() {
+  return (
+    <div>
+      <nav>
+        <Link to="/">Home</Link> | <Link to="/login">Login</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/rooms/:id" element={<Room />} />
+      </Routes>
+    </div>
+  );
+}

--- a/client/src/components/ApprovalPanel.tsx
+++ b/client/src/components/ApprovalPanel.tsx
@@ -1,0 +1,3 @@
+export default function ApprovalPanel() {
+  return <div>ApprovalPanel component</div>;
+}

--- a/client/src/components/Composer.tsx
+++ b/client/src/components/Composer.tsx
@@ -1,0 +1,3 @@
+export default function Composer() {
+  return <div>Composer component</div>;
+}

--- a/client/src/components/InviteDialog.tsx
+++ b/client/src/components/InviteDialog.tsx
@@ -1,0 +1,3 @@
+export default function InviteDialog() {
+  return <div>InviteDialog component</div>;
+}

--- a/client/src/components/MessageList.tsx
+++ b/client/src/components/MessageList.tsx
@@ -1,0 +1,3 @@
+export default function MessageList() {
+  return <div>MessageList component</div>;
+}

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -1,0 +1,3 @@
+export default function PostCard() {
+  return <div>PostCard component</div>;
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,4 @@
+export async function api(path: string, opts: RequestInit = {}) {
+  const res = await fetch(path, opts);
+  return res.json();
+}

--- a/client/src/lib/md.ts
+++ b/client/src/lib/md.ts
@@ -1,0 +1,2 @@
+import MarkdownIt from 'markdown-it';
+export const md = new MarkdownIt();

--- a/client/src/lib/time.ts
+++ b/client/src/lib/time.ts
@@ -1,0 +1,3 @@
+export function formatDate(d: string) {
+  return new Date(d).toLocaleString();
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home Page</div>;
+}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <div>Login Page</div>;
+}

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -1,0 +1,3 @@
+export default function Room() {
+  return <div>Room Page</div>;
+}

--- a/client/src/store/auth.ts
+++ b/client/src/store/auth.ts
@@ -1,0 +1,3 @@
+import create from 'zustand';
+
+export const useAuthStore = create(() => ({}));

--- a/client/src/store/rooms.ts
+++ b/client/src/store/rooms.ts
@@ -1,0 +1,3 @@
+import create from 'zustand';
+
+export const useRoomsStore = create(() => ({}));

--- a/client/src/store/timeline.ts
+++ b/client/src/store/timeline.ts
@@ -1,0 +1,3 @@
+import create from 'zustand';
+
+export const useTimelineStore = create(() => ({}));

--- a/client/src/store/ws.ts
+++ b/client/src/store/ws.ts
@@ -1,0 +1,3 @@
+import create from 'zustand';
+
+export const useWsStore = create(() => ({}));

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: parseInt(process.env.CLIENT_PORT || '5173') }
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  server:
+    build: ./server
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.example
+    volumes:
+      - ./server/uploads:/app/uploads
+  client:
+    build: ./client
+    ports:
+      - "5173:5173"
+    env_file:
+      - .env.example

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "app_connect-monorepo",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "concurrently -c cyan,magenta -n server,client \"pnpm -C server dev\" \"pnpm -C client dev\"",
+    "lint": "eslint \"**/*.{ts,tsx}\"",
+    "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0",
+    "eslint": "^8.57.0",
+    "prettier": "^3.1.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'server'
+  - 'client'

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+CMD ["node", "dist/index.js"]

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "app_connect-server",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "nodemon src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "better-sqlite3": "^8.6.0",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5",
+    "nanoid": "^5.0.2",
+    "ws": "^8.16.0",
+    "zod": "^3.22.4",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/node": "^20.11.30",
+    "@types/ws": "^8.5.8",
+    "nodemon": "^3.0.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import Database from 'better-sqlite3';
+import path from 'path';
+
+const dbPath = path.join(process.cwd(), 'data.db');
+const db = new Database(dbPath);
+
+db.pragma('journal_mode = WAL');
+db.pragma('busy_timeout = 5000');
+db.pragma('foreign_keys = ON');
+
+const schema = fs.readFileSync(path.join(__dirname, 'sql', 'schema.sql'), 'utf8');
+db.exec(schema);
+
+console.log('migrated');

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -1,0 +1,1 @@
+console.log('seed placeholder');

--- a/server/src/db/sql/schema.sql
+++ b/server/src/db/sql/schema.sql
@@ -1,0 +1,92 @@
+-- users
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  handle TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- sessions
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT REFERENCES users(id),
+  refresh_token_hash TEXT NOT NULL,
+  ua_fingerprint TEXT,
+  expires_at TEXT,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+);
+
+-- invites
+CREATE TABLE IF NOT EXISTS invites (
+  id TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL,
+  issued_to TEXT,
+  uses_remaining INTEGER,
+  expires_at TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- rooms
+CREATE TABLE IF NOT EXISTS rooms (
+  id TEXT PRIMARY KEY,
+  owner_id TEXT REFERENCES users(id),
+  name TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- room_members
+CREATE TABLE IF NOT EXISTS room_members (
+  room_id TEXT REFERENCES rooms(id),
+  user_id TEXT REFERENCES users(id),
+  role TEXT CHECK(role IN ('owner','mod','member')),
+  UNIQUE(room_id, user_id)
+);
+
+-- events
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  room_id TEXT REFERENCES rooms(id),
+  type TEXT CHECK(type IN ('message','post','media','system')),
+  author_id TEXT REFERENCES users(id),
+  body_md TEXT,
+  body_text TEXT,
+  meta_json TEXT,
+  version INTEGER DEFAULT 1,
+  created_at TEXT DEFAULT (datetime('now')),
+  deleted_at TEXT
+);
+
+-- approvals
+CREATE TABLE IF NOT EXISTS approvals (
+  event_id TEXT PRIMARY KEY REFERENCES events(id),
+  state TEXT CHECK(state IN ('pending','approved','rejected')),
+  decided_by TEXT REFERENCES users(id),
+  decided_at TEXT,
+  reason TEXT,
+  version INTEGER DEFAULT 1
+);
+
+-- user_timelines
+CREATE TABLE IF NOT EXISTS user_timelines (
+  user_id TEXT REFERENCES users(id),
+  event_id TEXT REFERENCES events(id),
+  room_id TEXT REFERENCES rooms(id),
+  visibility TEXT DEFAULT 'visible',
+  flagged_mine_only INTEGER DEFAULT 0,
+  PRIMARY KEY(user_id, event_id)
+);
+
+-- media
+CREATE TABLE IF NOT EXISTS media (
+  id TEXT PRIMARY KEY,
+  path TEXT NOT NULL,
+  sha256 TEXT,
+  mime TEXT,
+  size INTEGER,
+  uploaded_by TEXT REFERENCES users(id),
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_room_created ON events(room_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_approvals_state ON approvals(state);
+CREATE INDEX IF NOT EXISTS idx_timelines_user_room ON user_timelines(user_id, room_id);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import http from 'http';
+import dotenv from 'dotenv';
+import router from './routes/index.js';
+import { createHub } from './ws/hub.js';
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+app.use('/api', router);
+
+const server = http.createServer(app);
+const wss = new WebSocketServer({ server, path: '/ws' });
+createHub(wss);
+
+const port = process.env.SERVER_PORT || 3000;
+server.listen(port, () => {
+  console.log(`Server listening on ${port}`);
+});

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -1,0 +1,4 @@
+// auth helpers placeholder
+export function hashPassword(pw: string) {
+  return pw;
+}

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -1,0 +1,9 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+
+const dbPath = path.join(process.cwd(), 'data.db');
+export const db = new Database(dbPath);
+
+db.pragma('journal_mode = WAL');
+db.pragma('busy_timeout = 5000');
+db.pragma('foreign_keys = ON');

--- a/server/src/lib/ids.ts
+++ b/server/src/lib/ids.ts
@@ -1,0 +1,2 @@
+import { customAlphabet } from 'nanoid';
+export const id = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz', 12);

--- a/server/src/lib/invites.ts
+++ b/server/src/lib/invites.ts
@@ -1,0 +1,1 @@
+// invite helpers placeholder

--- a/server/src/lib/ratelimit.ts
+++ b/server/src/lib/ratelimit.ts
@@ -1,0 +1,1 @@
+// rate limit placeholder

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -1,0 +1,4 @@
+import { Router } from 'express';
+const router = Router();
+// TODO: implement approvals routes
+export default router;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,4 @@
+import { Router } from 'express';
+const router = Router();
+// TODO: implement auth routes
+export default router;

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -1,0 +1,4 @@
+import { Router } from 'express';
+const router = Router();
+// TODO: implement events routes
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/src/routes/invites.ts
+++ b/server/src/routes/invites.ts
@@ -1,0 +1,4 @@
+import { Router } from 'express';
+const router = Router();
+// TODO: implement invites routes
+export default router;

--- a/server/src/routes/media.ts
+++ b/server/src/routes/media.ts
@@ -1,0 +1,4 @@
+import { Router } from 'express';
+const router = Router();
+// TODO: implement media routes
+export default router;

--- a/server/src/routes/members.ts
+++ b/server/src/routes/members.ts
@@ -1,0 +1,4 @@
+import { Router } from 'express';
+const router = Router();
+// TODO: implement members routes
+export default router;

--- a/server/src/routes/rooms.ts
+++ b/server/src/routes/rooms.ts
@@ -1,0 +1,4 @@
+import { Router } from 'express';
+const router = Router();
+// TODO: implement rooms routes
+export default router;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: string;
+  handle: string;
+}

--- a/server/src/ws/hub.ts
+++ b/server/src/ws/hub.ts
@@ -1,0 +1,10 @@
+import { WebSocketServer, WebSocket } from 'ws';
+
+export function createHub(wss: WebSocketServer) {
+  wss.on('connection', (socket: WebSocket) => {
+    socket.on('message', (data) => {
+      // TODO: handle messages
+      console.log('ws message', data.toString());
+    });
+  });
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- setup pnpm workspace and tooling configs
- add Express+WS server skeleton with SQLite schema
- add Vite React client skeleton and Docker setup

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm run lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*


------
https://chatgpt.com/codex/tasks/task_e_689fbc7f61848320884f76fdaa2e9085